### PR TITLE
improve query arg parsing

### DIFF
--- a/sphinx_minipres/_static/minipres.js
+++ b/sphinx_minipres/_static/minipres.js
@@ -215,12 +215,9 @@ function hide() {
 
 var slideshow = minipres;
 
-if (window.location.search.indexOf('minipres')  != -1 ||
-    window.location.search.indexOf('slideshow') != -1 ||
-    window.location.search.indexOf('pres') != -1
-   ) {
+if (window.location.search.match(/[?&](minipres|slideshow|pres)([=&]|$)/) ) {
     //minipres()
     window.addEventListener("load", minipres);
-} else if (window.location.search.indexOf('plain') != -1) {
+} else if (window.location.search.match(/[?&](plain)([=&]|$)/) ) {
     window.addEventListener("load", hide);
 }


### PR DESCRIPTION
- Before, it would just look for "minipres", "plain" "slideshow" or
  "pres" in the query string.  But that would trigger even, for
  example, search=minipres, which is not idea.
- Now, look for these only in actual query argument names (but don't
  require a "=..." part.